### PR TITLE
Add wipe and variable for charging nozzle to prime line macro

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -4,6 +4,7 @@ gcode:
     {% set prime_line_length = params.LINE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_length)|float %}
     {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_purge_distance)|float %}
     {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _USER_VARIABLES"].prime_line_flowrate)|float %}
+    {% set charge_length = params.CHARGE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].charge_length)|float %}
 
     # Set internal macro vars
     {% set prime_line_x, prime_line_y = printer["gcode_macro _USER_VARIABLES"].prime_line_xy|map('float') %}
@@ -20,6 +21,8 @@ gcode:
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
     
     {% set line_height = 0.6 %}
+
+    {% set wipe_length = prime_line_length * 0.8 %}
 
     # some more Macro parameters after retrieving defaults
     {% set prime_line_x = params.START_X|default(prime_line_x)|float %}
@@ -82,14 +85,16 @@ gcode:
 
     # Add pressure in the nozzle
     G92 E0
-    G1 E18 F300
+    G1 E{charge_length} F300
 
     # Prime line
     G92 E0
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 X{prime_line_x + wipe_length} F{St}    
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 Y{prime_line_y + wipe_length} F{St}
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -60,6 +60,7 @@ variable_prime_line_direction: "X" # can also be set to "Y"
 variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
 variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 variable_prime_line_flowrate: 10 # mm3/s used for the prime line
+variable_charge_length: 18 # length of filament to pressurize the nozzle before starting the move
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1


### PR DESCRIPTION
Added a wipe after priming and a user configurable variable to set the pre-prime extrude distance, essentially charging the nozzle.