### PR TITLE
Remove _TIP_SHAPING from End/cancel print macros

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -20,7 +20,7 @@ gcode:
         {% endif %}
     {% else %}
         # pull back the filament a little bit
-        _TIP_SHAPING
+        G92 E0
         G1 E-10 F2100
     {% endif %}
 

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -22,7 +22,6 @@ gcode:
         {% endif %}
     {% else %}
         # pull back the filament a little bit
-        _TIP_SHAPING
         G92 E0
         G1 E-10 F2100
     {% endif %}


### PR DESCRIPTION
I'm not sure why this is called here, but it leaves an undesirable string that can cause issues with homing Z if not removed manually.