### PR TITLE
Turn on filter only if it was used during printing

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -12,6 +12,7 @@ gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
+    {% set filter_speed = printer["gcode_macro START_PRINT"].material.filter_speed|default(0)|int %}
 
     PARK
 
@@ -45,11 +46,11 @@ gcode:
     {% endif %}
 
 
-    # If a filter is connected, filter the air at full power
+    # If a filter is connected, and used during the print, continue filtering the air
     # for a couple of min before stopping everything
-    {% if filter_enabled %}
+    {% if filter_enabled and filter_speed > 0 %}
         {% set FILTER_TIME = params.FILTER_TIME|default(filter_default_time)|int %}
-        START_FILTER SPEED=1
+        START_FILTER SPEED={filter_speed / 100}
         UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION={FILTER_TIME}
     {% endif %}
 


### PR DESCRIPTION
I noticed my nevermore would run for 10 minutes after every print regardless of if it was used during the print, I think adding this conditional logic makes sense.