### PR TITLE
Add per material filament sensor switching

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,6 +46,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"
@@ -151,6 +152,10 @@ gcode:
     SET_GCODE_OFFSET Z_ADJUST={material.additional_z_offset} MOVE=1
     {% if filter_enabled %}
         START_FILTER SPEED={material.filter_speed / 100}
+    {% endif %}
+
+    {% if filament_sensor_enabled and not material.filament_sensor %}
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
     {% endif %}
 
     # And.... Goooo!

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -140,7 +140,7 @@ variable_print_default_material: "XXX"
 
 ## Material configuration parameters applied during START_PRINT by using the slicer MATERIAL variable
 ## FYI, retract paramaters are used only if firmware retraction is enabled, filter speed (in %) is used if
-## there is a filter installed on the machine, etc...
+## there is a filter installed on the machine, filament sensor is on or off if installed, etc...
 ## If you are using another material, just extend the list bellow with a new material and everything should work :)
 variable_material_parameters: {
         'PLA': {
@@ -150,7 +150,8 @@ variable_material_parameters: {
             'retract_speed': 40,
             'unretract_speed': 30,
             'filter_speed': 0,
-            'additional_z_offset': 0
+            'additional_z_offset': 0,
+            'filament_sensor': 1
         },
         'PET': {
             'pressure_advance': 0.0650,
@@ -159,7 +160,8 @@ variable_material_parameters: {
             'retract_speed': 30,
             'unretract_speed': 20,
             'filter_speed': 0,
-            'additional_z_offset': 0.020
+            'additional_z_offset': 0.020,
+            'filament_sensor': 1
         },
         'ABS': {
             'pressure_advance': 0.0480,
@@ -168,7 +170,8 @@ variable_material_parameters: {
             'retract_speed': 40,
             'unretract_speed': 30,
             'filter_speed': 80,
-            'additional_z_offset': 0
+            'additional_z_offset': 0,
+            'filament_sensor': 1
         }
     }
 


### PR DESCRIPTION
Filament sensors, at least my version of the BTT SFS put too much tension on flexible filaments like TPU so I've found a need to bypass it. This will allow users to enable or disable the sensor easily based on the filament type.